### PR TITLE
Add retry to the watch call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,15 @@ jobs:
       - name: Run Test Coverage
         run: ./gradlew jacocoTestReport
 
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.3
+        with:
+          paths: ${{ github.workspace }}/lib/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 50
+          min-coverage-changed-files: 50
+
       - name: Generate JaCoCo badge
         id: jacoco
         uses: cicirello/jacoco-badge-generator@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,18 +74,18 @@ jobs:
             git push
           fi
 
-      - name: Comment on PR with coverage percentages
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          REPORT=$(<badges/coverage-summary.json)
-          COVERAGE=$(jq -r '.coverage' <<< "$REPORT")%
-          BRANCHES=$(jq -r '.branches' <<< "$REPORT")%
-          NEWLINE=$'\n'
-          BODY="## JaCoCo Test Coverage Summary Statistics${NEWLINE}* __Coverage:__ ${COVERAGE}${NEWLINE}* __Branches:__ ${BRANCHES}"
-          gh pr comment ${{github.event.pull_request.number}} -b "${BODY}"
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Comment on PR with coverage percentages
+#        if: ${{ github.event_name == 'pull_request' }}
+#        run: |
+#          REPORT=$(<badges/coverage-summary.json)
+#          COVERAGE=$(jq -r '.coverage' <<< "$REPORT")%
+#          BRANCHES=$(jq -r '.branches' <<< "$REPORT")%
+#          NEWLINE=$'\n'
+#          BODY="## JaCoCo Test Coverage Summary Statistics${NEWLINE}* __Coverage:__ ${COVERAGE}${NEWLINE}* __Branches:__ ${BRANCHES}"
+#          gh pr comment ${{github.event.pull_request.number}} -b "${BODY}"
+#        continue-on-error: true
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 #  publish:
 #    name: Publish Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
           min-coverage-changed-files: 50
 
       - name: Generate JaCoCo badge
-        id: jacoco
         uses: cicirello/jacoco-badge-generator@v2
         with:
           jacoco-csv-file: lib/build/reports/jacoco/test/jacocoTestReport.csv

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ kubernetes-service-discovery-java
 =================================
 
 [![coverage](https://raw.githubusercontent.com/uharaqo/kubernetes-service-discovery-java/badges/jacoco.svg)](https://github.com/uharaqo/kubernetes-service-discovery-java/actions/workflows/build.yml)
+[![license](https://img.shields.io/badge/license-Apache%202-blue")](./LICENSE)
 
 Calls [the Kubernetes Endpoints API](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoints-v1/)
 to get or watch endpoints for a specified name.

--- a/buildSrc/src/main/groovy/java-lib.gradle
+++ b/buildSrc/src/main/groovy/java-lib.gradle
@@ -37,6 +37,7 @@ jacoco {
 jacocoTestReport {
     reports {
         csv.required = true
+        xml.required = true
     }
 }
 

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/KubernetesServiceDiscoveryBuilder.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/KubernetesServiceDiscoveryBuilder.java
@@ -18,6 +18,7 @@ public final class KubernetesServiceDiscoveryBuilder {
   @Nullable private SslContextProvider sslContextProvider;
   @Nullable private ServiceDiscoveryHttpHandlerFactory httpHandlerFactory;
   @Nullable private ServiceDiscoveryHttpRequestFactory requestFactory;
+  @Nullable private ServiceDiscoveryRetryConfig retryConfig;
 
   @Nonnull
   public KubernetesServiceDiscoveryBuilder withJsonDeserializer(
@@ -48,29 +49,20 @@ public final class KubernetesServiceDiscoveryBuilder {
   }
 
   @Nonnull
-  public KubernetesServiceDiscovery build() {
-    return build(deserializer, sslContextProvider, httpHandlerFactory, requestFactory);
+  public KubernetesServiceDiscoveryBuilder withRetryConfig(
+      ServiceDiscoveryRetryConfig retryConfig) {
+    this.retryConfig = retryConfig;
+    return this;
   }
 
-  public static KubernetesServiceDiscovery build(
-      ServiceDiscoveryJsonDeserializer deserializer,
-      SslContextProvider sslContextProvider,
-      ServiceDiscoveryHttpHandlerFactory httpHandlerFactory,
-      ServiceDiscoveryHttpRequestFactory requestFactory) {
-
-    //    Config c = defaultIfNull(config, () -> Config.builder().build());
-    ServiceDiscoveryJsonDeserializer json =
-        defaultIfNull(deserializer, DefaultServiceDiscoveryJsonDeserializer::new);
-    SslContextProvider ssl =
-        defaultIfNull(sslContextProvider, ServiceAccountSslContextProvider::new);
-
-    ServiceDiscoveryHttpHandlerFactory httpFactory =
-        defaultIfNull(httpHandlerFactory, DefaultServiceDiscoveryHttpHandlerFactory::new);
-
-    ServiceDiscoveryHttpHandler http = httpFactory.create(ssl, json);
-    ServiceDiscoveryHttpRequestFactory req =
-        defaultIfNull(requestFactory, DefaultServiceDiscoveryHttpRequestFactory::new);
-    return new DefaultKubernetesServiceDiscovery(http, req);
+  @Nonnull
+  public KubernetesServiceDiscovery build() {
+    return new DefaultKubernetesServiceDiscovery(
+        defaultIfNull(sslContextProvider, ServiceAccountSslContextProvider::new),
+        defaultIfNull(deserializer, DefaultServiceDiscoveryJsonDeserializer::new),
+        defaultIfNull(httpHandlerFactory, DefaultServiceDiscoveryHttpHandlerFactory::new),
+        defaultIfNull(requestFactory, DefaultServiceDiscoveryHttpRequestFactory::new),
+        defaultIfNull(retryConfig, ServiceDiscoveryRetryConfig::new));
   }
 
   private static <T> T defaultIfNull(T t, Supplier<T> defaultVal) {

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/ServiceDiscoveryException.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/ServiceDiscoveryException.java
@@ -2,6 +2,7 @@ package com.github.uharaqo.k8s.discovery;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.Getter;
 
 public final class ServiceDiscoveryException extends RuntimeException {
   private final ErrorCause errorCause;
@@ -17,10 +18,16 @@ public final class ServiceDiscoveryException extends RuntimeException {
     return errorCause;
   }
 
+  @Getter
   public enum ErrorCause {
-    HTTP,
-    HTTP_REQUEST_FACTORY,
-    SSL_CONTEXT_PROVIDER,
-    SETUP,
+    HTTP(true),
+    SETUP(false),
+    ;
+
+    private boolean recoverable;
+
+    ErrorCause(boolean recoverable) {
+      this.recoverable = recoverable;
+    }
   }
 }

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/ServiceDiscoveryRequest.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/ServiceDiscoveryRequest.java
@@ -1,10 +1,12 @@
 package com.github.uharaqo.k8s.discovery;
 
 import javax.annotation.Nonnull;
-import lombok.Value;
+import lombok.Data;
+import lombok.Generated;
 
-@Value
+@Data
+@Generated
 public class ServiceDiscoveryRequest {
-  @Nonnull public String namespace;
-  @Nonnull public String endpoint;
+  @Nonnull private final String namespace;
+  @Nonnull private final String endpoint;
 }

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/ServiceDiscoveryRetryConfig.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/ServiceDiscoveryRetryConfig.java
@@ -1,0 +1,16 @@
+package com.github.uharaqo.k8s.discovery;
+
+public final class ServiceDiscoveryRetryConfig {
+
+  public final int maxRetry;
+  public final long maxDurationMs;
+
+  public ServiceDiscoveryRetryConfig() {
+    this(3, 60_000L);
+  }
+
+  public ServiceDiscoveryRetryConfig(int maxRetry, long maxDurationMs) {
+    this.maxRetry = maxRetry;
+    this.maxDurationMs = maxDurationMs;
+  }
+}

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/ServiceDiscoveryRetryConfig.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/ServiceDiscoveryRetryConfig.java
@@ -1,16 +1,18 @@
 package com.github.uharaqo.k8s.discovery;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Generated;
+
+@Data
+@AllArgsConstructor
+@Generated
 public final class ServiceDiscoveryRetryConfig {
 
-  public final int maxRetry;
-  public final long maxDurationMs;
+  private final int maxRetry;
+  private final long maxDurationMillis;
 
   public ServiceDiscoveryRetryConfig() {
     this(3, 60_000L);
-  }
-
-  public ServiceDiscoveryRetryConfig(int maxRetry, long maxDurationMs) {
-    this.maxRetry = maxRetry;
-    this.maxDurationMs = maxDurationMs;
   }
 }

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/SimpleSubscriber.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/SimpleSubscriber.java
@@ -1,4 +1,4 @@
-package com.github.uharaqo.k8s.discovery.internal;
+package com.github.uharaqo.k8s.discovery;
 
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
@@ -27,9 +27,9 @@ public class SimpleSubscriber<T> implements Subscriber<T> {
   @Override
   public void onSubscribe(Subscription subscription) {
     this.subscription = subscription;
+    subscription.request(1);
     try {
       onSubscribe.accept(subscription);
-      subscription.request(1);
     } catch (Throwable t) {
       onError(t);
     }
@@ -38,8 +38,8 @@ public class SimpleSubscriber<T> implements Subscriber<T> {
   @Override
   public void onNext(T item) {
     try {
-      onNext.accept(item);
       subscription.request(1);
+      onNext.accept(item);
     } catch (Throwable t) {
       onError(t);
     }
@@ -47,8 +47,8 @@ public class SimpleSubscriber<T> implements Subscriber<T> {
 
   @Override
   public void onError(Throwable throwable) {
-    onError.accept(throwable);
     subscription.cancel();
+    onError.accept(throwable);
   }
 
   @Override

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/SslContextProvider.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/SslContextProvider.java
@@ -1,7 +1,7 @@
 package com.github.uharaqo.k8s.discovery;
 
+import java.util.Optional;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 
 public interface SslContextProvider {
@@ -12,16 +12,15 @@ public interface SslContextProvider {
    * @return SSLContext or null if secure protocol is not used
    * @throws Exception exception on creating an SSLContext
    */
-  @Nullable
-  SSLContext create() throws Exception;
+  @Nonnull
+  Optional<SSLContext> create() throws Exception;
 
-  static SslContextProvider noOp() {
-    return new SslContextProvider() {
-      @Nonnull
-      @Override
-      public SSLContext create() {
-        return null;
-      }
-    };
-  }
+  SslContextProvider PLAINTEXT =
+      new SslContextProvider() {
+        @Nonnull
+        @Override
+        public Optional<SSLContext> create() {
+          return Optional.empty();
+        }
+      };
 }

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/EndpointAddress.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/EndpointAddress.java
@@ -1,6 +1,7 @@
 package com.github.uharaqo.k8s.discovery.data;
 
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 
 /**
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @NoArgsConstructor
+@Generated
 public class EndpointAddress {
 
   private String hostname;

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/EndpointPort.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/EndpointPort.java
@@ -1,6 +1,7 @@
 package com.github.uharaqo.k8s.discovery.data;
 
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 
 /**
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @NoArgsConstructor
+@Generated
 public class EndpointPort {
 
   private String appProtocol;

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/EndpointSubset.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/EndpointSubset.java
@@ -2,6 +2,7 @@ package com.github.uharaqo.k8s.discovery.data;
 
 import java.util.List;
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 
 /**
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @NoArgsConstructor
+@Generated
 public class EndpointSubset {
 
   private List<EndpointAddress> addresses;

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/EndpointWatchEvent.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/EndpointWatchEvent.java
@@ -1,6 +1,7 @@
 package com.github.uharaqo.k8s.discovery.data;
 
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 
 /**
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @NoArgsConstructor
+@Generated
 public class EndpointWatchEvent {
 
   /**

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/Endpoints.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/Endpoints.java
@@ -2,6 +2,7 @@ package com.github.uharaqo.k8s.discovery.data;
 
 import java.util.List;
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 
 /**
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @NoArgsConstructor
+@Generated
 public class Endpoints {
 
   private String apiVersion;

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/ObjectMeta.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/ObjectMeta.java
@@ -2,6 +2,7 @@ package com.github.uharaqo.k8s.discovery.data;
 
 import java.util.Map;
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 
 /**
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @NoArgsConstructor
+@Generated
 public class ObjectMeta {
 
   private String clusterName;

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/ObjectReference.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/data/ObjectReference.java
@@ -1,6 +1,7 @@
 package com.github.uharaqo.k8s.discovery.data;
 
 import lombok.Data;
+import lombok.Generated;
 import lombok.NoArgsConstructor;
 
 /**
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
  */
 @Data
 @NoArgsConstructor
+@Generated
 public class ObjectReference {
 
   private String apiVersion;

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultKubernetesServiceDiscovery.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultKubernetesServiceDiscovery.java
@@ -1,34 +1,115 @@
 package com.github.uharaqo.k8s.discovery.internal;
 
+import static com.github.uharaqo.k8s.discovery.ServiceDiscoveryException.ErrorCause.SETUP;
+
 import com.github.uharaqo.k8s.discovery.KubernetesServiceDiscovery;
+import com.github.uharaqo.k8s.discovery.ServiceDiscoveryException;
 import com.github.uharaqo.k8s.discovery.ServiceDiscoveryHttpHandler;
+import com.github.uharaqo.k8s.discovery.ServiceDiscoveryHttpHandlerFactory;
 import com.github.uharaqo.k8s.discovery.ServiceDiscoveryHttpRequestFactory;
+import com.github.uharaqo.k8s.discovery.ServiceDiscoveryJsonDeserializer;
 import com.github.uharaqo.k8s.discovery.ServiceDiscoveryRequest;
+import com.github.uharaqo.k8s.discovery.ServiceDiscoveryRetryConfig;
+import com.github.uharaqo.k8s.discovery.SimpleSubscriber;
+import com.github.uharaqo.k8s.discovery.SslContextProvider;
 import com.github.uharaqo.k8s.discovery.data.EndpointWatchEvent;
 import com.github.uharaqo.k8s.discovery.data.Endpoints;
+import java.net.http.HttpRequest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Publisher;
-import lombok.AllArgsConstructor;
+import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /** The main class that manages the discovery process. */
-@AllArgsConstructor
 public final class DefaultKubernetesServiceDiscovery implements KubernetesServiceDiscovery {
 
-  private final ServiceDiscoveryHttpHandler http;
-  private final ServiceDiscoveryHttpRequestFactory factory;
+  private final ServiceDiscoveryHttpRequestFactory requestFactory;
+  private final SslContextProvider sslContextProvider;
+  private final ServiceDiscoveryJsonDeserializer deserializer;
+  private final ServiceDiscoveryHttpHandlerFactory httpHandlerFactory;
+  private final AtomicReference<ServiceDiscoveryHttpHandler> httpHandlerCache =
+      new AtomicReference<>();
+  private final ServiceDiscoveryRetryConfig retryConfig;
+
+  public DefaultKubernetesServiceDiscovery(
+      SslContextProvider sslContextProvider,
+      ServiceDiscoveryJsonDeserializer deserializer,
+      ServiceDiscoveryHttpHandlerFactory httpHandlerFactory,
+      ServiceDiscoveryHttpRequestFactory requestFactory,
+      ServiceDiscoveryRetryConfig retryConfig) {
+    this.sslContextProvider = sslContextProvider;
+    this.deserializer = deserializer;
+    this.httpHandlerFactory = httpHandlerFactory;
+    this.requestFactory = requestFactory;
+    this.retryConfig = retryConfig;
+
+    refreshHttpHandler();
+  }
 
   @Override
   public CompletableFuture<Endpoints> getEndpoints(ServiceDiscoveryRequest request) {
-    return http.getEndpoints(factory.forGet(request));
+    return httpHandlerCache.get().getEndpoints(requestFactory.forGet(request));
   }
 
   @Override
   public Publisher<EndpointWatchEvent> watchChanges(ServiceDiscoveryRequest request) {
-    return http.watchEndpoints(factory.forWatch(request));
+    SubmissionPublisher<EndpointWatchEvent> publisher = new SubmissionPublisher<>();
+
+    ServiceDiscoveryHttpHandler httpHandler = httpHandlerCache.get();
+
+    watchChanges(
+        publisher, request, httpHandler, new DefaultServiceDiscoveryRetryStrategy(retryConfig));
+
+    return publisher;
+  }
+
+  private void watchChanges(
+      SubmissionPublisher<EndpointWatchEvent> publisher,
+      ServiceDiscoveryRequest request,
+      ServiceDiscoveryHttpHandler httpHandler,
+      ServiceDiscoveryRetryStrategy errorHandlingStrategy) {
+
+    HttpRequest httpRequest = requestFactory.forWatch(request);
+
+    SimpleSubscriber<EndpointWatchEvent> subscriber =
+        new SimpleSubscriber<>(
+            s -> {},
+            publisher::submit,
+            t ->
+                errorHandlingStrategy
+                    .next(t)
+                    .ifPresentOrElse(
+                        strategy -> {
+                          // cancel the current subscription and retry with a new handler because
+                          // it might be due to expired SSL / token
+                          Logger.getLogger(DefaultServiceDiscoveryHttpHandler.class.getName())
+                              .log(Level.WARNING, "HTTP error. Retrying the watch call", t);
+                          watchChanges(publisher, request, refreshHttpHandler(), strategy);
+                        },
+                        () -> publisher.closeExceptionally(t)),
+            () -> watchChanges(publisher, request, httpHandler, errorHandlingStrategy));
+
+    httpHandler.watchEndpoints(httpRequest).subscribe(subscriber);
+  }
+
+  private ServiceDiscoveryHttpHandler refreshHttpHandler() {
+    ServiceDiscoveryHttpHandler newHandler =
+        httpHandlerFactory.create(sslContextProvider, deserializer);
+    ServiceDiscoveryHttpHandler prev = httpHandlerCache.getAndSet(newHandler);
+    try {
+      if (prev != null) {
+        prev.close();
+      }
+    } catch (Exception e) {
+      throw new ServiceDiscoveryException(SETUP, "Failed to close HttpHandler", e);
+    }
+    return newHandler;
   }
 
   @Override
   public void close() throws Exception {
-    http.close();
+    httpHandlerCache.get().close();
   }
 }

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryHttpHandler.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryHttpHandler.java
@@ -1,7 +1,7 @@
 package com.github.uharaqo.k8s.discovery.internal;
 
 import static com.github.uharaqo.k8s.discovery.ServiceDiscoveryException.ErrorCause.HTTP;
-import static com.github.uharaqo.k8s.discovery.ServiceDiscoveryException.ErrorCause.SSL_CONTEXT_PROVIDER;
+import static com.github.uharaqo.k8s.discovery.ServiceDiscoveryException.ErrorCause.SETUP;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -11,15 +11,16 @@ import com.github.uharaqo.k8s.discovery.ServiceDiscoveryJsonDeserializer;
 import com.github.uharaqo.k8s.discovery.SslContextProvider;
 import com.github.uharaqo.k8s.discovery.data.EndpointWatchEvent;
 import com.github.uharaqo.k8s.discovery.data.Endpoints;
+import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.SubmissionPublisher;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLContext;
@@ -35,21 +36,18 @@ public final class DefaultServiceDiscoveryHttpHandler implements ServiceDiscover
       Duration connectTimeout) {
 
     HttpClient.Builder builder = HttpClient.newBuilder();
-    SSLContext sslContext = newSslContext(sslContextProvider);
-    if (sslContext != null) {
-      builder.sslContext(sslContext);
-    }
+    newSslContext(sslContextProvider).ifPresent(builder::sslContext);
     httpClient = builder.connectTimeout(connectTimeout).build();
     this.deserializer = deserializer;
   }
 
-  private static SSLContext newSslContext(SslContextProvider sslContextProvider) {
+  private static Optional<SSLContext> newSslContext(SslContextProvider sslContextProvider) {
     try {
       return sslContextProvider.create();
     } catch (ServiceDiscoveryException e) {
       throw e;
     } catch (Exception e) {
-      throw new ServiceDiscoveryException(SSL_CONTEXT_PROVIDER, "Failed to create SSLContext", e);
+      throw new ServiceDiscoveryException(SETUP, "Failed to create SSLContext", e);
     }
   }
 
@@ -60,77 +58,86 @@ public final class DefaultServiceDiscoveryHttpHandler implements ServiceDiscover
         .sendAsync(request, BodyHandlers.ofString(UTF_8))
         .thenApply(
             r -> {
-              try {
-                int statusCode = r.statusCode();
-                String body = r.body();
+              int statusCode = r.statusCode();
+              String body = r.body();
 
-                if (statusCode == 200) {
-                  return deserializer.deserializeEndpoints(body);
-                  //                } else if (r.statusCode() == 403) {
-                  // TODO can't continue
-                }
-
-                throw new ServiceDiscoveryException(
-                    HTTP,
-                    format("HTTP Error Response. status: %d, body: %s", statusCode, body),
-                    null);
-              } catch (ServiceDiscoveryException e) {
-                throw e;
-              } catch (Exception e) {
-                throw new ServiceDiscoveryException(HTTP, "HTTP call failed", e);
+              if (statusCode == 200) {
+                return parseEndpoints(body);
               }
+
+              throw new ServiceDiscoveryException(
+                  HTTP,
+                  format("HTTP Error Response. status: %d, body: %s", statusCode, body),
+                  null);
             });
   }
 
   @Nonnull
   @Override
   public Publisher<EndpointWatchEvent> watchEndpoints(HttpRequest request) {
-
     SubmissionPublisher<EndpointWatchEvent> publisher = new SubmissionPublisher<>();
+
     httpClient
         .sendAsync(request, BodyHandlers.ofLines())
         .whenComplete(
             (r, t) -> {
               try {
                 if (t != null) {
-                  publisher.closeExceptionally(
-                      new ServiceDiscoveryException(HTTP, "HTTP call failed", t));
-
-                  //                } else if (r.statusCode() == 403) {
-                  // TODO can't continue
-
-                } else if (r.statusCode() != 200) {
-                  String body =
-                      r != null && r.body() != null
-                          ? r.body().collect(Collectors.joining(System.lineSeparator()))
-                          : "";
-                  publisher.closeExceptionally(
-                      new ServiceDiscoveryException(HTTP, "HTTP error response: " + body, null));
-
-                } else {
-                  Consumer<String> f =
-                      body -> {
-                        try {
-                          EndpointWatchEvent event = deserializer.deserializeEndpointEvent(body);
-                          publisher.offer(event, 1000L, TimeUnit.MILLISECONDS, (s, ep) -> false);
-
-                        } catch (Exception e) {
-                          publisher.closeExceptionally(
-                              new ServiceDiscoveryException(
-                                  HTTP, "Failed to parse the response: " + body, e));
-                        }
-                      };
-
-                  r.body().forEach(f);
-                  publisher.close();
+                  throw new ServiceDiscoveryException(HTTP, "HTTP call failed", t);
                 }
+
+                int statusCode = r.statusCode();
+                if (statusCode != 200) {
+                  String body = r.body().collect(Collectors.joining(System.lineSeparator()));
+                  throw new ServiceDiscoveryException(
+                      HTTP,
+                      format("HTTP Error Response. status: %d, body: %s", statusCode, body),
+                      null);
+                }
+
+                // TODO: can this response be null?
+                r.body()
+                    .map(this::parseWatchEvents)
+                    .forEach(event -> publishEvent(publisher, event));
+
+                publisher.close();
+
+              } catch (ServiceDiscoveryException e) {
+                publisher.closeExceptionally(e);
               } catch (Exception e) {
                 publisher.closeExceptionally(
-                    new ServiceDiscoveryException(HTTP, "Unexpected Exception", e));
+                    new ServiceDiscoveryException(HTTP, "Unexpected HTTP Exception", e));
               }
             });
 
     return publisher;
+  }
+
+  private Endpoints parseEndpoints(String body) {
+    try {
+      return deserializer.deserializeEndpoints(body);
+    } catch (IOException e) {
+      throw new ServiceDiscoveryException(HTTP, "Failed to parse HTTP response: " + body, e);
+    }
+  }
+
+  private EndpointWatchEvent parseWatchEvents(String body) {
+    try {
+      return deserializer.deserializeEndpointEvent(body);
+    } catch (Exception e) {
+      throw new ServiceDiscoveryException(HTTP, "Failed to parse HTTP response: " + body, e);
+    }
+  }
+
+  private static void publishEvent(
+      SubmissionPublisher<EndpointWatchEvent> publisher, EndpointWatchEvent event) {
+    try {
+      publisher.offer(event, 100L, TimeUnit.MILLISECONDS, (s, ep) -> false);
+
+    } catch (Exception e) {
+      publisher.closeExceptionally(
+          new ServiceDiscoveryException(HTTP, "Failed to publish event: " + event, e));
+    }
   }
 
   @Override

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryHttpRequestFactory.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryHttpRequestFactory.java
@@ -1,8 +1,6 @@
 package com.github.uharaqo.k8s.discovery.internal;
 
-import static com.github.uharaqo.k8s.discovery.ServiceDiscoveryException.ErrorCause.HTTP_REQUEST_FACTORY;
 import static com.github.uharaqo.k8s.discovery.ServiceDiscoveryException.ErrorCause.SETUP;
-import static com.github.uharaqo.k8s.discovery.ServiceDiscoveryException.ErrorCause.SSL_CONTEXT_PROVIDER;
 import static java.lang.String.format;
 
 import com.github.uharaqo.k8s.discovery.ServiceDiscoveryException;
@@ -83,18 +81,12 @@ public final class DefaultServiceDiscoveryHttpRequestFactory
   }
 
   private HttpRequest newRequest(Supplier<URI> uri, int timeoutSec) {
-    try {
-      return HttpRequest.newBuilder()
-          .GET()
-          .uri(uri.get())
-          .headers(getHeaders(tokenFilePath))
-          .timeout(Duration.ofSeconds(timeoutSec * 2))
-          .build();
-    } catch (ServiceDiscoveryException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new ServiceDiscoveryException(SSL_CONTEXT_PROVIDER, "Unknown Exception", e);
-    }
+    return HttpRequest.newBuilder()
+        .GET()
+        .uri(uri.get())
+        .headers(getHeaders(getAuthHeader(tokenFilePath)))
+        .timeout(Duration.ofSeconds(timeoutSec * 2))
+        .build();
   }
 
   private static URI getNamespacesUri(String protocol, String host, String portText) {
@@ -111,23 +103,22 @@ public final class DefaultServiceDiscoveryHttpRequestFactory
     try {
       return baseUri.resolve(uri);
     } catch (Exception e) {
-      throw new ServiceDiscoveryException(
-          HTTP_REQUEST_FACTORY, "Invalid Resource Names: " + uri, e);
+      throw new ServiceDiscoveryException(SETUP, "Invalid Resource Names: " + uri, e);
     }
   }
 
-  private static String[] getHeaders(Path tokenFilePath) {
-    try {
-      return new String[] {
-        "Authorization",
-        "Bearer " + Files.readString(tokenFilePath),
-        "User-Agent",
-        "KubernetesServiceDiscovery",
-      };
+  private static String[] getHeaders(String authHeader) {
+    return new String[] {
+      "Authorization", authHeader, "User-Agent", "KubernetesServiceDiscovery",
+    };
+  }
 
+  private static String getAuthHeader(Path tokenFilePath) {
+    try {
+      return "Bearer " + Files.readString(tokenFilePath);
     } catch (Exception e) {
       throw new ServiceDiscoveryException(
-          HTTP_REQUEST_FACTORY, "Failed to read access token: " + tokenFilePath, e);
+          SETUP, "Failed to read access token: " + tokenFilePath, e);
     }
   }
 }

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryHttpRequestFactory.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryHttpRequestFactory.java
@@ -61,8 +61,8 @@ public final class DefaultServiceDiscoveryHttpRequestFactory
             resolveUrl(
                 nameSpacesBaseUri,
                 "%s/endpoints/%s?pretty=false&timeoutSeconds=%s",
-                request.namespace,
-                request.endpoint,
+                request.getNamespace(),
+                request.getEndpoint(),
                 String.valueOf(getTimeoutSec)),
         getTimeoutSec);
   }
@@ -74,8 +74,8 @@ public final class DefaultServiceDiscoveryHttpRequestFactory
             resolveUrl(
                 nameSpacesBaseUri,
                 "%s/endpoints?watch=true&fieldSelector=metadata.name=%s&timeoutSeconds=%s",
-                request.namespace,
-                request.endpoint,
+                request.getNamespace(),
+                request.getEndpoint(),
                 String.valueOf(watchTimeoutSec)),
         watchTimeoutSec);
   }

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryJsonDeserializer.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryJsonDeserializer.java
@@ -6,7 +6,9 @@ import com.github.uharaqo.k8s.discovery.data.Endpoints;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.json.bind.JsonbConfig;
+import jakarta.json.bind.JsonbException;
 import jakarta.json.bind.config.PropertyOrderStrategy;
+import java.io.IOException;
 import javax.annotation.Nonnull;
 
 /**
@@ -25,13 +27,21 @@ public final class DefaultServiceDiscoveryJsonDeserializer
 
   @Nonnull
   @Override
-  public Endpoints deserializeEndpoints(String body) {
-    return jsonb.fromJson(body, Endpoints.class);
+  public Endpoints deserializeEndpoints(String body) throws IOException {
+    return deserialize(body, Endpoints.class);
   }
 
   @Nonnull
   @Override
-  public EndpointWatchEvent deserializeEndpointEvent(String body) {
-    return jsonb.fromJson(body, EndpointWatchEvent.class);
+  public EndpointWatchEvent deserializeEndpointEvent(String body) throws IOException {
+    return deserialize(body, EndpointWatchEvent.class);
+  }
+
+  private <T> T deserialize(String json, Class<T> clazz) throws IOException {
+    try {
+      return jsonb.fromJson(json, clazz);
+    } catch (JsonbException e) {
+      throw new IOException("Failed to parse response", e);
+    }
   }
 }

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryRetryStrategy.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryRetryStrategy.java
@@ -1,0 +1,35 @@
+package com.github.uharaqo.k8s.discovery.internal;
+
+import com.github.uharaqo.k8s.discovery.ServiceDiscoveryException;
+import com.github.uharaqo.k8s.discovery.ServiceDiscoveryRetryConfig;
+import java.time.Instant;
+import java.util.Optional;
+
+public final class DefaultServiceDiscoveryRetryStrategy implements ServiceDiscoveryRetryStrategy {
+  // TODO: backoff
+
+  private final int remainingRetry;
+  private final Instant deadline;
+
+  public DefaultServiceDiscoveryRetryStrategy(ServiceDiscoveryRetryConfig retryConfig) {
+    remainingRetry = retryConfig.maxRetry;
+    deadline = Instant.now().plusMillis(retryConfig.maxDurationMs);
+  }
+
+  public DefaultServiceDiscoveryRetryStrategy(int remainingRetry, Instant deadline) {
+    this.remainingRetry = remainingRetry;
+    this.deadline = deadline;
+  }
+
+  @Override
+  public Optional<ServiceDiscoveryRetryStrategy> next(Throwable t) {
+    // TODO
+    if (t instanceof ServiceDiscoveryException
+        && ((ServiceDiscoveryException) t).getErrorCause().isRecoverable()) {
+      if (0 < remainingRetry && Instant.now().isBefore(deadline)) {
+        return Optional.of(new DefaultServiceDiscoveryRetryStrategy(remainingRetry - 1, deadline));
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryRetryStrategy.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/DefaultServiceDiscoveryRetryStrategy.java
@@ -12,8 +12,8 @@ public final class DefaultServiceDiscoveryRetryStrategy implements ServiceDiscov
   private final Instant deadline;
 
   public DefaultServiceDiscoveryRetryStrategy(ServiceDiscoveryRetryConfig retryConfig) {
-    remainingRetry = retryConfig.maxRetry;
-    deadline = Instant.now().plusMillis(retryConfig.maxDurationMs);
+    remainingRetry = retryConfig.getMaxRetry();
+    deadline = Instant.now().plusMillis(retryConfig.getMaxDurationMillis());
   }
 
   public DefaultServiceDiscoveryRetryStrategy(int remainingRetry, Instant deadline) {

--- a/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/ServiceDiscoveryRetryStrategy.java
+++ b/lib/src/main/java/com/github/uharaqo/k8s/discovery/internal/ServiceDiscoveryRetryStrategy.java
@@ -1,0 +1,14 @@
+package com.github.uharaqo.k8s.discovery.internal;
+
+import java.util.Optional;
+
+public interface ServiceDiscoveryRetryStrategy {
+
+  /**
+   * Provide the next strategy.
+   *
+   * @param t error
+   * @return the next strategy or null on no more retry.
+   */
+  Optional<ServiceDiscoveryRetryStrategy> next(Throwable t);
+}

--- a/lib/src/test/java/com/github/uharaqo/k8s/discovery/IntegrationTest.java
+++ b/lib/src/test/java/com/github/uharaqo/k8s/discovery/IntegrationTest.java
@@ -3,39 +3,37 @@ package com.github.uharaqo.k8s.discovery;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.uharaqo.k8s.discovery.data.EndpointWatchEvent;
+import com.github.uharaqo.k8s.discovery.internal.DefaultServiceDiscoveryHttpHandlerFactory;
 import com.github.uharaqo.k8s.discovery.internal.DefaultServiceDiscoveryHttpRequestFactory;
-import com.github.uharaqo.k8s.discovery.internal.MockKubeApiServer;
+import com.github.uharaqo.k8s.discovery.internal.DefaultServiceDiscoveryJsonDeserializer;
+import com.github.uharaqo.k8s.discovery.testutil.MockKubeApiServer;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Flow.Subscriber;
-import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import lombok.val;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class IntegrationTest {
 
-  private final ServiceDiscoveryRequest request = new ServiceDiscoveryRequest("ns1", "ep1");
+  private static final ServiceDiscoveryRequest request = new ServiceDiscoveryRequest("ns1", "ep1");
 
-  private final DefaultServiceDiscoveryHttpRequestFactory requestFactory =
+  private static final DefaultServiceDiscoveryHttpRequestFactory requestFactory =
       new DefaultServiceDiscoveryHttpRequestFactory(
           "http",
           "127.0.0.1",
           "1080",
-          getClass().getClassLoader().getResource("token").getPath().toString(),
+          IntegrationTest.class.getClassLoader().getResource("token").getPath().toString(),
           5,
           60);
-  private KubernetesServiceDiscovery client =
-      KubernetesServiceDiscovery.builder()
-          .withHttpRequestFactory(requestFactory)
-          .withSslContextProvider(SslContextProvider.noOp())
-          .build();
+  private static KubernetesServiceDiscovery client;
 
-  private MockKubeApiServer mockServer;
+  private static MockKubeApiServer mockServer;
 
-  private String mockGetResponse =
+  private static String mockGetResponse =
       "{\"kind\":\"Endpoints\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"ep1\",\"namespace\":\"ns1\",\"uid\":\"161b9670-4f11-412d-b8f8-3150c4827a99\",\"resourceVersion\":\"1022092107\",\"creationTimestamp\":\"2021-06-28T21:10:41Z\",\"labels\":{\"app\":\"app1\"},\"annotations\":{\"endpoints.kubernetes.io/last-change-trigger-time\":\"2022-09-14T20:00:54Z\"},\"managedFields\":[{\"manager\":\"kube-controller-manager\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2022-09-14T20:00:21Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:endpoints.kubernetes.io/last-change-trigger-time\":{}},\"f:labels\":{\".\":{},\"f:app\":{},\"f:app.kubernetes.io/managed-by\":{},\"f:service.kubernetes.io/headless\":{}}},\"f:subsets\":{}}}]},\"subsets\":[{\"addresses\":[{\"ip\":\"10.0.0.101\",\"nodeName\":\"node1\",\"targetRef\":{\"kind\":\"Pod\",\"namespace\":\"ns1\",\"name\":\"ns1-v20220908233031-app1-7945fdf498-47dtx\",\"uid\":\"db58349a-0ccc-4a3c-8782-5cea25163ef7\",\"resourceVersion\":\"1006548709\"}},{\"ip\":\"10.0.0.201\",\"nodeName\":\"node2\",\"targetRef\":{\"kind\":\"Pod\",\"namespace\":\"ns1\",\"name\":\"ns1-v20220908233031-app1-7945fdf498-prscr\",\"uid\":\"4e65ed4e-0e36-421d-ae10-8481d12a4c88\",\"resourceVersion\":\"1022092100\"}}],\"ports\":[{\"name\":\"grpc\",\"port\":50051,\"protocol\":\"TCP\"},{\"name\":\"http\",\"port\":8080,\"protocol\":\"TCP\"}]}]}";
 
   private String firstWatchEvent =
@@ -46,16 +44,25 @@ public class IntegrationTest {
           "{\"type\":\"MODIFIED\",\"object\":{\"kind\":\"Endpoints\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"ep1\",\"namespace\":\"ns1\",\"uid\":\"161b9670-4f11-412d-b8f8-3150c4827a99\",\"resourceVersion\":\"1022091052\",\"creationTimestamp\":\"2021-06-28T21:10:41Z\",\"labels\":{\"app\":\"app1\"},\"annotations\":{\"endpoints.kubernetes.io/last-change-trigger-time\":\"2022-09-14T20:00:20Z\"},\"managedFields\":[{\"manager\":\"kube-controller-manager\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2022-09-14T20:00:21Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:endpoints.kubernetes.io/last-change-trigger-time\":{}},\"f:labels\":{\".\":{},\"f:app\":{},\"f:app.kubernetes.io/managed-by\":{},\"f:service.kubernetes.io/headless\":{}}},\"f:subsets\":{}}}]},\"subsets\":[{\"addresses\":[{\"ip\":\"10.0.0.101\",\"nodeName\":\"node1\",\"targetRef\":{\"kind\":\"Pod\",\"namespace\":\"ns1\",\"name\":\"ns1-v20220908233031-app1-7945fdf498-47dtx\",\"uid\":\"db58349a-0ccc-4a3c-8782-5cea25163ef7\",\"resourceVersion\":\"1006548709\"}}],\"notReadyAddresses\":[{\"ip\":\"10.0.0.201\",\"nodeName\":\"node2\",\"targetRef\":{\"kind\":\"Pod\",\"namespace\":\"ns1\",\"name\":\"ns1-v20220908233031-app1-7945fdf498-prscr\",\"uid\":\"4e65ed4e-0e36-421d-ae10-8481d12a4c88\",\"resourceVersion\":\"1022091046\"}}],\"ports\":[{\"name\":\"grpc\",\"port\":50051,\"protocol\":\"TCP\"},{\"name\":\"http\",\"port\":8080,\"protocol\":\"TCP\"}]}]}}",
           "{\"type\":\"MODIFIED\",\"object\":{\"kind\":\"Endpoints\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"ep1\",\"namespace\":\"ns1\",\"uid\":\"161b9670-4f11-412d-b8f8-3150c4827a99\",\"resourceVersion\":\"1022092107\",\"creationTimestamp\":\"2021-06-28T21:10:41Z\",\"labels\":{\"app\":\"app1\"},\"annotations\":{\"endpoints.kubernetes.io/last-change-trigger-time\":\"2022-09-14T20:00:54Z\"},\"managedFields\":[{\"manager\":\"kube-controller-manager\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2022-09-14T20:00:21Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:endpoints.kubernetes.io/last-change-trigger-time\":{}},\"f:labels\":{\".\":{},\"f:app\":{},\"f:app.kubernetes.io/managed-by\":{},\"f:service.kubernetes.io/headless\":{}}},\"f:subsets\":{}}}]},\"subsets\":[{\"addresses\":[{\"ip\":\"10.0.0.101\",\"nodeName\":\"node1\",\"targetRef\":{\"kind\":\"Pod\",\"namespace\":\"ns1\",\"name\":\"ns1-v20220908233031-app1-7945fdf498-47dtx\",\"uid\":\"db58349a-0ccc-4a3c-8782-5cea25163ef7\",\"resourceVersion\":\"1006548709\"}},{\"ip\":\"10.0.0.201\",\"nodeName\":\"node2\",\"targetRef\":{\"kind\":\"Pod\",\"namespace\":\"ns1\",\"name\":\"ns1-v20220908233031-app1-7945fdf498-prscr\",\"uid\":\"4e65ed4e-0e36-421d-ae10-8481d12a4c88\",\"resourceVersion\":\"1022092100\"}}],\"ports\":[{\"name\":\"grpc\",\"port\":50051,\"protocol\":\"TCP\"},{\"name\":\"http\",\"port\":8080,\"protocol\":\"TCP\"}]}]}}");
 
-  @BeforeEach
-  void init() throws Exception {
+  @BeforeAll
+  static void init() throws Exception {
     mockServer = new MockKubeApiServer();
     mockServer.setMockGetResponse(mockGetResponse);
     mockServer.start(requestFactory, request);
+    client =
+        KubernetesServiceDiscovery.builder()
+            .withHttpRequestFactory(requestFactory)
+            .withSslContextProvider(SslContextProvider.PLAINTEXT)
+            .withJsonDeserializer(new DefaultServiceDiscoveryJsonDeserializer())
+            .withHttpHandlerFactory(new DefaultServiceDiscoveryHttpHandlerFactory())
+            .withRetryConfig(new ServiceDiscoveryRetryConfig(1, 60_000L))
+            .build();
   }
 
-  @AfterEach
-  void shutdown() {
+  @AfterAll
+  static void shutdown() throws Exception {
     mockServer.close();
+    client.close();
   }
 
   @Test
@@ -84,23 +91,55 @@ public class IntegrationTest {
   @Test
   void watch_request() throws InterruptedException {
     mockServer.addWatchResponse(firstWatchEvent);
-    addEvents();
+    addWatchEvents();
 
     LinkedBlockingQueue<EndpointWatchEvent> q = new LinkedBlockingQueue<>();
+    CountDownLatch latch = new CountDownLatch(1);
 
-    client.watchChanges(request).subscribe(new EndpointWatchEventSubscriber(q));
+    client
+        .watchChanges(request)
+        .subscribe(
+            new SimpleSubscriber<>(
+                s -> System.out.println("started"),
+                q::offer,
+                t -> {
+                  System.out.println("error");
+                  t.printStackTrace();
+                  latch.countDown();
+                },
+                () -> {
+                  System.out.println("closed");
+                  latch.countDown();
+                }));
 
     List<EndpointWatchEvent> l1 = waitForEvents(q, 4);
     assertEquals(4, l1.size(), "Couldn't receive all expected events");
+    assertEquals(1L, latch.getCount());
 
-    addEvents();
+    addWatchEvents();
     List<EndpointWatchEvent> l2 = waitForEvents(q, 3);
     assertEquals(3, l2.size(), "Couldn't receive all expected events");
 
-    mockServer.stop();
+    mockServer.closeSession();
+    assertEquals(1L, latch.getCount());
+
+    // the client should make another request
+    mockServer.addWatchResponse(firstWatchEvent);
+    addWatchEvents();
+    List<EndpointWatchEvent> l3 = waitForEvents(q, 4);
+    assertEquals(4, l3.size(), "Couldn't receive all expected events");
+    assertEquals(1L, latch.getCount());
+
+    // the client will retry once
+    mockServer.addWatchResponse("Dummy Invalid Response 1");
+    mockServer.closeSession();
+    mockServer.addWatchResponse("Dummy Invalid Response 2");
+    mockServer.closeSession();
+    latch.await(5000, TimeUnit.MILLISECONDS);
+    assertEquals(0L, latch.getCount());
   }
 
-  private void addEvents() {
+  private void addWatchEvents() {
     mockWatchResponses.forEach(r -> mockServer.addWatchResponse(r));
   }
 
@@ -115,39 +154,5 @@ public class IntegrationTest {
     List<EndpointWatchEvent> l = new ArrayList<>();
     q.drainTo(l);
     return l;
-  }
-
-  private static class EndpointWatchEventSubscriber implements Subscriber<EndpointWatchEvent> {
-
-    private Subscription subsceiption;
-    private LinkedBlockingQueue<EndpointWatchEvent> q;
-
-    public EndpointWatchEventSubscriber(LinkedBlockingQueue<EndpointWatchEvent> q) {
-      this.q = q;
-    }
-
-    @Override
-    public void onSubscribe(Subscription subscription) {
-      this.subsceiption = subscription;
-      subsceiption.request(1);
-    }
-
-    @Override
-    public void onNext(EndpointWatchEvent item) {
-      q.offer(item);
-      System.out.println(item);
-      subsceiption.request(1);
-    }
-
-    @Override
-    public void onError(Throwable throwable) {
-      throwable.printStackTrace();
-      subsceiption.cancel();
-    }
-
-    @Override
-    public void onComplete() {
-      System.out.println("completed");
-    }
   }
 }

--- a/lib/src/test/java/com/github/uharaqo/k8s/discovery/JsonDeserializerTest.java
+++ b/lib/src/test/java/com/github/uharaqo/k8s/discovery/JsonDeserializerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.github.uharaqo.k8s.discovery.data.EndpointWatchEvent;
 import com.github.uharaqo.k8s.discovery.data.Endpoints;
 import com.github.uharaqo.k8s.discovery.internal.DefaultServiceDiscoveryJsonDeserializer;
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ public class JsonDeserializerTest {
       new DefaultServiceDiscoveryJsonDeserializer();
 
   @Test
-  void get_response() {
+  void get_response() throws IOException {
     Endpoints result = sut.deserializeEndpoints(mockGetResponse);
 
     assertEquals(
@@ -50,7 +51,16 @@ public class JsonDeserializerTest {
   @Test
   void watch_responses() {
     List<EndpointWatchEvent> deserialized =
-        mockWatchResponses.stream().map(sut::deserializeEndpointEvent).collect(Collectors.toList());
+        mockWatchResponses.stream()
+            .map(
+                body -> {
+                  try {
+                    return sut.deserializeEndpointEvent(body);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.toList());
 
     assertEquals(
         "EndpointWatchEvent(type=ADDED, object=Endpoints(apiVersion=v1, kind=Endpoints,"

--- a/lib/src/test/java/com/github/uharaqo/k8s/discovery/data/EndpointExtractorTest.java
+++ b/lib/src/test/java/com/github/uharaqo/k8s/discovery/data/EndpointExtractorTest.java
@@ -1,0 +1,46 @@
+package com.github.uharaqo.k8s.discovery.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EndpointExtractorTest {
+
+  @Test
+  void extract() throws UnknownHostException {
+    EndpointPort port1 = new EndpointPort();
+    port1.setPort(1111);
+    EndpointPort port2 = new EndpointPort();
+    port2.setPort(2222);
+
+    EndpointAddress addr1 = new EndpointAddress();
+    addr1.setHostname("localhost");
+    addr1.setIp("11.11.11.99");
+    addr1.setNodeName("node1");
+    EndpointAddress addr2 = new EndpointAddress();
+    addr2.setHostname("localhost");
+    addr2.setIp("11.11.11.11");
+    addr2.setNodeName("node2");
+
+    EndpointSubset ss1 = new EndpointSubset();
+    ss1.setPorts(List.of(port1));
+    ss1.setAddresses(List.of(addr1, addr2));
+    EndpointSubset ss2 = new EndpointSubset();
+    ss2.setPorts(List.of(port1, port2));
+    ss2.setAddresses(List.of(addr1, addr2));
+    List<EndpointSubset> subsets = List.of(ss1, ss2);
+
+    Endpoints eps = new Endpoints();
+    eps.setSubsets(subsets);
+
+    List<InetAddress> results =
+        EndpointExtractor.getAddressesForPort(eps, p -> p.getPort() == 2222);
+
+    assertEquals(
+        List.of(InetAddress.getByName(addr2.getIp()), InetAddress.getByName(addr1.getIp())),
+        results);
+  }
+}

--- a/lib/src/test/java/com/github/uharaqo/k8s/discovery/internal/ServiceAccountSslContextProviderTest.java
+++ b/lib/src/test/java/com/github/uharaqo/k8s/discovery/internal/ServiceAccountSslContextProviderTest.java
@@ -1,0 +1,20 @@
+package com.github.uharaqo.k8s.discovery.internal;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import javax.net.ssl.SSLContext;
+import org.junit.jupiter.api.Test;
+
+class ServiceAccountSslContextProviderTest {
+
+  @Test
+  void ssl_context_successfully_created() throws Exception {
+    String testCertPath =
+        ServiceAccountSslContextProviderTest.class.getClassLoader().getResource("ca.crt").getPath();
+
+    ServiceAccountSslContextProvider provider = new ServiceAccountSslContextProvider(testCertPath);
+    Optional<SSLContext> ctx = provider.create();
+    assertTrue(ctx.isPresent());
+  }
+}

--- a/lib/src/test/java/com/github/uharaqo/k8s/discovery/testutil/MockKubeApiServer.java
+++ b/lib/src/test/java/com/github/uharaqo/k8s/discovery/testutil/MockKubeApiServer.java
@@ -1,12 +1,15 @@
-package com.github.uharaqo.k8s.discovery.internal;
+package com.github.uharaqo.k8s.discovery.testutil;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.uharaqo.k8s.discovery.ServiceDiscoveryHttpRequestFactory;
 import com.github.uharaqo.k8s.discovery.ServiceDiscoveryRequest;
 import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -14,17 +17,21 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class MockKubeApiServer {
 
+  private final ExecutorService es = Executors.newCachedThreadPool();
   private final AtomicReference<String> mockGetResponse = new AtomicReference<>("CHANGEME_GET");
   private final LinkedBlockingQueue<String> mockWatchResponses = new LinkedBlockingQueue<>();
-  private final AtomicBoolean isActive = new AtomicBoolean(true);
+  private final AtomicBoolean sessionActive = new AtomicBoolean(true);
 
   private HttpServer server;
 
-  public void start(
-      ServiceDiscoveryHttpRequestFactory requestFactory, ServiceDiscoveryRequest request)
-      throws Exception {
+  public MockKubeApiServer start(
+      ServiceDiscoveryHttpRequestFactory requestFactory, ServiceDiscoveryRequest request) {
 
-    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 1080), 0);
+    try {
+      server = HttpServer.create(new InetSocketAddress("127.0.0.1", 1080), 0);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
 
     server.createContext(
         requestFactory.forGet(request).uri().getPath(),
@@ -39,26 +46,30 @@ public class MockKubeApiServer {
 
     server.createContext(
         requestFactory.forWatch(request).uri().getPath(),
-        exchange -> {
-          OutputStream out = exchange.getResponseBody();
+        exchange ->
+            es.submit(
+                () -> {
+                  try {
+                    OutputStream out = exchange.getResponseBody();
 
-          exchange.sendResponseHeaders(200, 0);
-          while (isActive.get()) {
-            try {
-              String ev = mockWatchResponses.poll(100, TimeUnit.MILLISECONDS);
-              if (ev != null) {
-                out.write(ev.getBytes(UTF_8));
-                out.write("\r\n".getBytes(UTF_8));
-                out.flush();
-              }
-            } catch (Exception e) {
-              throw new RuntimeException(e);
-            }
-          }
-          out.close();
-        });
+                    exchange.sendResponseHeaders(200, 0);
+                    while (sessionActive.get()) {
+                      String ev = mockWatchResponses.poll(100, TimeUnit.MILLISECONDS);
+                      if (ev != null) {
+                        out.write(ev.getBytes(UTF_8));
+                        out.write("\r\n".getBytes(UTF_8));
+                        out.flush();
+                      }
+                    }
+                    out.close();
+                    sessionActive.set(true);
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                }));
 
     server.start();
+    return this;
   }
 
   public void setMockGetResponse(String mockGetResponse) {
@@ -69,12 +80,13 @@ public class MockKubeApiServer {
     this.mockWatchResponses.offer(watchResponse);
   }
 
-  public void stop() {
-    this.isActive.set(false);
+  public void closeSession() {
+    this.sessionActive.set(false);
   }
 
   public void close() {
-    stop();
+    closeSession();
+    es.shutdownNow();
     if (server != null) {
       server.stop(0);
     }

--- a/lombok.conf
+++ b/lombok.conf
@@ -1,1 +1,0 @@
-lombok.addLombokGeneratedAnnotation = true

--- a/test-app/src/main/java/com/github/uharaqo/k8s/discovery/App.java
+++ b/test-app/src/main/java/com/github/uharaqo/k8s/discovery/App.java
@@ -4,7 +4,6 @@ import com.github.uharaqo.k8s.discovery.data.EndpointExtractor;
 import com.github.uharaqo.k8s.discovery.data.EndpointWatchEvent;
 import com.github.uharaqo.k8s.discovery.data.Endpoints;
 import com.github.uharaqo.k8s.discovery.internal.DefaultServiceDiscoveryHttpHandler;
-import com.github.uharaqo.k8s.discovery.internal.SimpleSubscriber;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.json.bind.JsonbConfig;


### PR DESCRIPTION
We want to keep watching endpoint changes until we close the client. But there are some reasons to call the API with watch periodically:
- An access token might get refreshed in the background
- The watch call returns GET endpoint result on connection, then emit changes
- It's important to fetch a full list of endpoints once in a while
- Temporary errors such as timeout or connection close sometimes happen

This PR makes the watch method periodically call the API until an unrecoverable error happen. A simple retry configuration also gets introduced.